### PR TITLE
Add Spring Boot welcome API template and devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "Spring Boot DevContainer",
+  "image": "mcr.microsoft.com/devcontainers/java:1-21-bullseye",
+  "features": {
+    "ghcr.io/devcontainers/features/maven:1": {
+      "version": "3.9"
+    }
+  },
+  "postCreateCommand": "mvn -q -ntp dependency:go-offline",
+  "forwardPorts": [8080],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "vscjava.vscode-java-pack",
+        "vmware.vscode-spring-boot",
+        "pivotal.vscode-spring-boot-dev-pack"
+      ]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Maven
+/target/
+!.mvn/wrapper/maven-wrapper.jar
+
+# IDEs
+.idea/
+.project
+.classpath
+.settings/
+*.iml
+
+# VS Code
+.vscode/
+
+# OS Files
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
-# template-devcontainer-springboot
+# Plantilla Spring Boot con DevContainers
+
+Este repositorio ofrece una plantilla lista para usar que combina un proyecto Spring Boot con la configuración necesaria para ejecutarlo dentro de un [Dev Container](https://containers.dev/). Está pensado como punto de partida para crear APIs Java modernas manteniendo un entorno de desarrollo reproducible.
+
+## Características principales
+
+- **Spring Boot 3.2** con Java 21 y Maven.
+- API REST sencilla con dos endpoints:
+  - `GET /api/welcome`: devuelve el mensaje de bienvenida actual.
+  - `POST /api/welcome`: actualiza el mensaje de bienvenida (requiere un cuerpo JSON con el campo `message`).
+- Cobertura de pruebas automatizadas mediante `MockMvc`.
+- Configuración de Dev Container para trabajar de forma consistente en VS Code o GitHub Codespaces.
+
+## Requisitos previos
+
+- [VS Code](https://code.visualstudio.com/) con la extensión **Dev Containers** o acceso a **GitHub Codespaces**.
+- Docker instalado y ejecutándose si se usa VS Code en local.
+
+## Uso del Dev Container
+
+1. Abre el repositorio en VS Code.
+2. Cuando se te solicite, selecciona **Reopen in Container** (o usa el comando `Dev Containers: Reopen in Container`).
+3. La imagen incluye Java 21 y Maven. Tras la construcción del contenedor se ejecuta `mvn dependency:go-offline` para precargar dependencias.
+
+## Ejecución de la aplicación
+
+Una vez dentro del Dev Container (o en tu entorno local con Java 21 y Maven):
+
+```bash
+mvn spring-boot:run
+```
+
+La API estará disponible en `http://localhost:8080`.
+
+### Ejemplo de peticiones
+
+- Obtener el mensaje actual:
+
+  ```bash
+  curl http://localhost:8080/api/welcome
+  ```
+
+- Actualizar el mensaje:
+
+  ```bash
+  curl -X POST http://localhost:8080/api/welcome \
+       -H "Content-Type: application/json" \
+       -d '{"message": "Hola desde Dev Containers"}'
+  ```
+
+## Pruebas
+
+Ejecuta la suite de pruebas con:
+
+```bash
+mvn test
+```
+
+## Personalización
+
+- Modifica el mensaje de bienvenida por defecto editando `src/main/resources/application.properties` (`app.welcome-message`).
+- Añade nuevas dependencias en `pom.xml` según las necesidades de tu proyecto.
+- Ajusta la configuración del contenedor en `.devcontainer/devcontainer.json` para incluir herramientas adicionales.
+
+## Licencia
+
+Este proyecto se distribuye bajo la licencia [MIT](LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>devcontainer-springboot-template</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>DevContainer Spring Boot Template</name>
+    <description>Spring Boot template project configured for development containers.</description>
+    <packaging>jar</packaging>
+
+    <properties>
+        <java.version>21</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <spring-boot.version>3.2.4</spring-boot.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/template/DevcontainerSpringbootTemplateApplication.java
+++ b/src/main/java/com/example/template/DevcontainerSpringbootTemplateApplication.java
@@ -1,0 +1,16 @@
+package com.example.template;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+import com.example.template.config.WelcomeProperties;
+
+@SpringBootApplication
+@EnableConfigurationProperties(WelcomeProperties.class)
+public class DevcontainerSpringbootTemplateApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(DevcontainerSpringbootTemplateApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/template/api/WelcomeController.java
+++ b/src/main/java/com/example/template/api/WelcomeController.java
@@ -1,0 +1,38 @@
+package com.example.template.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.template.api.dto.WelcomeMessageRequest;
+import com.example.template.api.dto.WelcomeMessageResponse;
+import com.example.template.service.WelcomeService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/welcome")
+public class WelcomeController {
+
+    private final WelcomeService welcomeService;
+
+    public WelcomeController(WelcomeService welcomeService) {
+        this.welcomeService = welcomeService;
+    }
+
+    @GetMapping
+    public ResponseEntity<WelcomeMessageResponse> getWelcomeMessage() {
+        String message = welcomeService.getWelcomeMessage();
+        return ResponseEntity.ok(new WelcomeMessageResponse(message));
+    }
+
+    @PostMapping
+    public ResponseEntity<WelcomeMessageResponse> updateWelcomeMessage(
+            @RequestBody @Valid WelcomeMessageRequest request) {
+        String message = welcomeService.updateWelcomeMessage(request.message());
+        return ResponseEntity.ok(new WelcomeMessageResponse(message));
+    }
+}

--- a/src/main/java/com/example/template/api/dto/WelcomeMessageRequest.java
+++ b/src/main/java/com/example/template/api/dto/WelcomeMessageRequest.java
@@ -1,0 +1,10 @@
+package com.example.template.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record WelcomeMessageRequest(
+        @NotBlank(message = "El mensaje de bienvenida no puede estar vacío.")
+        @Size(max = 255, message = "El mensaje de bienvenida no puede superar los 255 caracteres.")
+        String message) {
+}

--- a/src/main/java/com/example/template/api/dto/WelcomeMessageResponse.java
+++ b/src/main/java/com/example/template/api/dto/WelcomeMessageResponse.java
@@ -1,0 +1,4 @@
+package com.example.template.api.dto;
+
+public record WelcomeMessageResponse(String message) {
+}

--- a/src/main/java/com/example/template/config/WelcomeProperties.java
+++ b/src/main/java/com/example/template/config/WelcomeProperties.java
@@ -1,0 +1,17 @@
+package com.example.template.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app")
+public class WelcomeProperties {
+
+    private String welcomeMessage = "¡Bienvenido a tu plantilla de Spring Boot!";
+
+    public String getWelcomeMessage() {
+        return welcomeMessage;
+    }
+
+    public void setWelcomeMessage(String welcomeMessage) {
+        this.welcomeMessage = welcomeMessage;
+    }
+}

--- a/src/main/java/com/example/template/service/WelcomeService.java
+++ b/src/main/java/com/example/template/service/WelcomeService.java
@@ -1,0 +1,26 @@
+package com.example.template.service;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.springframework.stereotype.Service;
+
+import com.example.template.config.WelcomeProperties;
+
+@Service
+public class WelcomeService {
+
+    private final AtomicReference<String> welcomeMessage;
+
+    public WelcomeService(WelcomeProperties properties) {
+        this.welcomeMessage = new AtomicReference<>(properties.getWelcomeMessage());
+    }
+
+    public String getWelcomeMessage() {
+        return welcomeMessage.get();
+    }
+
+    public String updateWelcomeMessage(String message) {
+        welcomeMessage.set(message);
+        return welcomeMessage.get();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+spring.application.name=devcontainer-springboot-template
+
+# Mensaje de bienvenida configurable
+app.welcome-message=Hola desde tu entorno de desarrollo en contenedor!

--- a/src/test/java/com/example/template/api/WelcomeControllerTest.java
+++ b/src/test/java/com/example/template/api/WelcomeControllerTest.java
@@ -1,0 +1,45 @@
+package com.example.template.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class WelcomeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldReturnDefaultWelcomeMessage() throws Exception {
+        mockMvc.perform(get("/api/welcome"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Hola desde tu entorno de desarrollo en contenedor!"));
+    }
+
+    @Test
+    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+    void shouldUpdateWelcomeMessage() throws Exception {
+        String payload = "{\"message\":\"Hola, DevContainer!\"}";
+
+        mockMvc.perform(post("/api/welcome")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Hola, DevContainer!"));
+
+        mockMvc.perform(get("/api/welcome"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Hola, DevContainer!"));
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold a Spring Boot 3.2 project with configurable welcome message APIs and supporting service layer
- add request validation, configuration properties, and MockMvc tests for the welcome endpoints
- configure a development container, documentation, and gitignore entries for a reproducible setup

## Testing
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68dcdd7c9644832d8e270c84f90e134d